### PR TITLE
add new reference to sources

### DIFF
--- a/app/templates/sources.html
+++ b/app/templates/sources.html
@@ -37,6 +37,7 @@
                 <a target="_blank" rel="noopener" class="list-group-item list-group-item" href="https://www.england.nhs.uk/rtt/">NHS England - Referral to treatment guidelines</a>
                 <a target="_blank" rel="noopener" class="list-group-item list-group-item" href="https://www.transinformed.co.uk/static/files/rcp-cr181.pdf">Royal College of Psychiatrists - guidelines for treating adults with gender dysphoria</a>
                 <a target="_blank" rel="noopener" class="list-group-item list-group-item" href="https://www.transinformed.co.uk/static/files/gmc-ce-letter.pdf">Letter from Susan Goldsmith - Chief Executive of the GMC</a>
+                <a target="_blank" rel="noopener" class="list-group-item list-group-item" href="https://www.transinformed.co.uk/static/files/Endocrine-management-of-gender-dysphoria-in-adults.pdf">NHS Wales - Endocrine Management of Gender Dysphoria in Adults: Prescribing Guidance for Non-specialist Practitioners </a>
             </ul>
         </div>
     </main>


### PR DESCRIPTION
adds NHS Wales - Endocrine Management of Gender Dysphoria in Adults: Prescribing Guidance for Non-specialist Practitioners to sources